### PR TITLE
hotfix: change packages structure from object to array in source.json

### DIFF
--- a/source.json
+++ b/source.json
@@ -14,8 +14,9 @@
     },
     "bannerUrl":"banner.png",
     "githubRepos":[],
-    "packages":{
-        "com.rieslab.test-vpm-package":{
+    "packages":[
+        {
+            "name":"com.rieslab.test-vpm-package",
             "versions":{
                 "0.0.1":{
                     "name":"com.rieslab.test-vpm-package",
@@ -33,5 +34,5 @@
                 }
             }
         }
-    }
+    ]
 }


### PR DESCRIPTION
```
Newtonsoft.Json.JsonSerializationException: Cannot deserialize the current JSON object (e.g. {"name":"value"}) into type 'System.Collections.Generic.List`1[VRC.PackageManagement.Automation.Multi.PackageInfo]' because the type requires a JSON array (e.g. [1,2,3]) to deserialize correctly.
```